### PR TITLE
XRDDEV-898

### DIFF
--- a/setup_security_server_sidecar.sh
+++ b/setup_security_server_sidecar.sh
@@ -28,7 +28,7 @@ docker network inspect xroad-network >/dev/null 2>&1 || docker network create -d
 echo "=====> Build sidecar image"
 docker build -f sidecar/Dockerfile --build-arg XROAD_ADMIN_USER=$4 --build-arg XROAD_ADMIN_PASSWORD=$5 -t xroad-sidecar-security-server-image sidecar/
 echo "=====> Run container"
-docker run --detach -p $2:4000 -p $httpport:80 --network xroad-network -e XROAD_TOKEN_PIN=$3 --name $1 xroad-sidecar-security-server-image
+docker run --detach -p $2:4000 -p $httpport:80 -p 5588:5588 --network xroad-network -e XROAD_TOKEN_PIN=$3 --name $1 xroad-sidecar-security-server-image
 
 printf "\n
 Sidecar security server software token PIN is set to $3

--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -38,8 +38,11 @@ RUN pg_ctlcluster 10 main start \
 && rm -f $CERTS_PATH/internal.crt $CERTS_PATH/internal.key $CERTS_PATH/nginx.crt $CERTS_PATH/nginx.key \
 && sed -i 's/proxy_set_header Host $host:$server_port;/proxy_set_header Host $http_host;/' /etc/xroad/nginx/default-xroad.conf
 
+RUN crudini --set /etc/xroad/conf.d/local.ini proxy health-check-interface 0.0.0.0 \
+&& crudini --set /etc/xroad/conf.d/local.ini proxy health-check-port 5588
+
 COPY files/ss-entrypoint.sh /root/entrypoint.sh
 COPY --chown=root:root files/ss-xroad.conf /etc/supervisor/conf.d/xroad.conf
 CMD ["/root/entrypoint.sh"]
 
-EXPOSE 80 443 4000 5500 5577
+EXPOSE 80 443 4000 5500 5577 5588


### PR DESCRIPTION
- Publish health check port 5588 and map to the host port 5588 on the first run of the container.
- Added local.ini proxy configuration to enable health check interface and port.