### PR TITLE
XRDDEV-896

### DIFF
--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -53,6 +53,7 @@ RUN mkdir -p /root/etc/xroad \
 COPY files/ss-entrypoint.sh /root/entrypoint.sh
 COPY --chown=root:root files/ss-xroad.conf /etc/supervisor/conf.d/xroad.conf
 COPY --chown=xroad:xroad files/local.conf /etc/xroad/services/local.conf
+COPY --chown=xroad:xroad files/*logback* /etc/xroad/conf.d/
 CMD ["/root/entrypoint.sh"]
 
 EXPOSE 80 443 4000 5500 5577 5588

--- a/sidecar/files/confclient-logback-service.xml
+++ b/sidecar/files/confclient-logback-service.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+
+    <property name="logOutputPath" value="/var/log/xroad" />
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${logOutputPath}/configuration_client.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/configuration_client.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="ee.ria.xroad" level="INFO" />
+    <logger name="ee.ria.xroad.common.SystemPropertiesLoader" level="OFF" />
+
+    <root level="INFO">
+        <appender-ref ref="FILE" />
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/sidecar/files/confclient-logback-service.xml
+++ b/sidecar/files/confclient-logback-service.xml
@@ -1,20 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration>
 
-    <property name="logOutputPath" value="/var/log/xroad" />
-
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${logOutputPath}/configuration_client.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/configuration_client.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
-            <maxFileSize>100MB</maxFileSize>
-        </rollingPolicy>
-        <encoder>
-            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
-            <charset>UTF-8</charset>
-        </encoder>
-    </appender>
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %level [xroad-confclient-service] [%thread] %logger{36} - %msg%n%rEx{3}</pattern>
@@ -28,7 +14,4 @@
         <appender-ref ref="STDOUT" />
     </root>
 
-    <root level="ERROR">
-        <appender-ref ref="STDOUT" />
-    </root>
 </configuration>

--- a/sidecar/files/confclient-logback-service.xml
+++ b/sidecar/files/confclient-logback-service.xml
@@ -17,7 +17,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d %level [xroad-confclient-service] [%thread] %logger{36} - %msg%n%rEx{3}</pattern>
         </encoder>
     </appender>
 
@@ -25,7 +25,6 @@
     <logger name="ee.ria.xroad.common.SystemPropertiesLoader" level="OFF" />
 
     <root level="INFO">
-        <appender-ref ref="FILE" />
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/sidecar/files/confclient-logback.xml
+++ b/sidecar/files/confclient-logback.xml
@@ -1,20 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration scan="true" scanPeriod="60 seconds">
 
-    <property name="logOutputPath" value="/var/log/xroad" />
-
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${logOutputPath}/configuration_client.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/configuration_client.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
-            <maxFileSize>100MB</maxFileSize>
-        </rollingPolicy>
-        <encoder>
-            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
-            <charset>UTF-8</charset>
-        </encoder>
-    </appender>
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %level [xroad-confclient] [%thread] %logger{36} - %msg%n%rEx{3}</pattern>
@@ -29,7 +15,4 @@
         <appender-ref ref="STDOUT" />
     </root>
 
-    <root level="ERROR">
-        <appender-ref ref="STDOUT" />
-    </root>
 </configuration>

--- a/sidecar/files/confclient-logback.xml
+++ b/sidecar/files/confclient-logback.xml
@@ -17,7 +17,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d %level [xroad-confclient] [%thread] %logger{36} - %msg%n%rEx{3}</pattern>
         </encoder>
     </appender>
 
@@ -26,8 +26,6 @@
     <logger name="ee.ria.xroad.common.SystemPropertiesLoader" level="OFF" />
 
     <root level="INFO">
-        <appender-ref ref="STDOUT" />
-        <appender-ref ref="FILE" />
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/sidecar/files/confclient-logback.xml
+++ b/sidecar/files/confclient-logback.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration scan="true" scanPeriod="60 seconds">
+
+    <property name="logOutputPath" value="/var/log/xroad" />
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${logOutputPath}/configuration_client.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/configuration_client.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="ee.ria.xroad" level="INFO" />
+    <logger name="akka" level="WARN" />
+    <logger name="ee.ria.xroad.common.SystemPropertiesLoader" level="OFF" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/sidecar/files/jetty-logback.xml
+++ b/sidecar/files/jetty-logback.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include optional="true" file="/etc/xroad/conf.d/jetty-logback-context-name.xml"/>
+
+    <property name="logOutputPath" value="/var/log/xroad/jetty"/>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${logOutputPath}/jetty.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/jetty.%d{yyyy-MM-dd}-%i.log.zip</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <appender name="SYSLOG" class="ch.qos.logback.classic.net.SyslogAppender">
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+                <marker>AUDIT</marker>
+            </evaluator>
+            <onMismatch>DENY</onMismatch>
+            <onMatch>NEUTRAL</onMatch>
+        </filter>
+        <syslogHost>localhost</syslogHost>
+        <port>514</port>
+        <facility>LOCAL0</facility>
+        <suffixPattern>%-5level [%contextName] %d{yyyy-MM-dd HH:mm:ssZ} - %msg</suffixPattern>
+    </appender>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="ee.ria.xroad" level="INFO"/>
+    <root level="INFO">
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="SYSLOG"/>
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/sidecar/files/jetty-logback.xml
+++ b/sidecar/files/jetty-logback.xml
@@ -1,34 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <configuration>
-    <include optional="true" file="/etc/xroad/conf.d/jetty-logback-context-name.xml"/>
-
-    <property name="logOutputPath" value="/var/log/xroad/jetty"/>
-
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${logOutputPath}/jetty.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/jetty.%d{yyyy-MM-dd}-%i.log.zip</fileNamePattern>
-            <maxFileSize>100MB</maxFileSize>
-        </rollingPolicy>
-        <encoder>
-            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
-            <charset>UTF-8</charset>
-        </encoder>
-    </appender>
-
-    <appender name="SYSLOG" class="ch.qos.logback.classic.net.SyslogAppender">
-        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
-                <marker>AUDIT</marker>
-            </evaluator>
-            <onMismatch>DENY</onMismatch>
-            <onMatch>NEUTRAL</onMatch>
-        </filter>
-        <syslogHost>localhost</syslogHost>
-        <port>514</port>
-        <facility>LOCAL0</facility>
-        <suffixPattern>%-5level [%contextName] %d{yyyy-MM-dd HH:mm:ssZ} - %msg</suffixPattern>
-    </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -36,12 +7,10 @@
         </encoder>
     </appender>
 
-    <logger name="ee.ria.xroad" level="INFO"/>
+    <logger name="ee.ria.xroad" level="INFO" />
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 
-    <root level="ERROR">
-        <appender-ref ref="STDOUT" />
-    </root>
 </configuration>

--- a/sidecar/files/jetty-logback.xml
+++ b/sidecar/files/jetty-logback.xml
@@ -32,14 +32,12 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d %level [xroad-jetty] [%thread] %logger{36} - %msg%n%rEx{3}</pattern>
         </encoder>
     </appender>
 
     <logger name="ee.ria.xroad" level="INFO"/>
     <root level="INFO">
-        <appender-ref ref="FILE"/>
-        <appender-ref ref="SYSLOG"/>
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/sidecar/files/proxy-logback.xml
+++ b/sidecar/files/proxy-logback.xml
@@ -41,7 +41,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d %level [xroad-proxy] [%thread] %logger{36} - %msg%n%rEx{3}</pattern>
         </encoder>
     </appender>
 
@@ -57,7 +57,6 @@
     <logger name="akka" level="WARN" />
 
     <root level="INFO">
-        <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/sidecar/files/proxy-logback.xml
+++ b/sidecar/files/proxy-logback.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration scan="true" scanPeriod="60 seconds">
+
+    <property name="logOutputPath" value="/var/log/xroad"/>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${logOutputPath}/proxy.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/proxy.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <appender name="clientproxy-access-log" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${logOutputPath}/clientproxy_access.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/clientproxy_access.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <appender name="serverproxy-access-log" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${logOutputPath}/serverproxy_access.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/serverproxy_access.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="ee.ria.xroad.proxy.clientproxy.RequestLog" level="INFO" additivity="false">
+        <appender-ref ref="clientproxy-access-log"/>
+    </logger>
+
+    <logger name="ee.ria.xroad.proxy.serverproxy.RequestLog" level="INFO" additivity="false">
+        <appender-ref ref="serverproxy-access-log"/>
+    </logger>
+
+    <logger name="ee.ria.xroad" level="INFO"/>
+    <logger name="akka" level="WARN" />
+
+    <root level="INFO">
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/sidecar/files/proxy-logback.xml
+++ b/sidecar/files/proxy-logback.xml
@@ -1,20 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration scan="true" scanPeriod="60 seconds">
 
-    <property name="logOutputPath" value="/var/log/xroad"/>
-
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${logOutputPath}/proxy.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/proxy.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
-            <maxFileSize>100MB</maxFileSize>
-        </rollingPolicy>
-        <encoder>
-            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
-            <charset>UTF-8</charset>
-        </encoder>
-    </appender>
-
     <appender name="clientproxy-access-log" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${logOutputPath}/clientproxy_access.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
@@ -60,7 +46,4 @@
         <appender-ref ref="STDOUT" />
     </root>
 
-    <root level="ERROR">
-        <appender-ref ref="STDOUT" />
-    </root>
 </configuration>

--- a/sidecar/files/proxy-logback.xml
+++ b/sidecar/files/proxy-logback.xml
@@ -1,45 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration scan="true" scanPeriod="60 seconds">
 
-    <appender name="clientproxy-access-log" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${logOutputPath}/clientproxy_access.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/clientproxy_access.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
-            <maxFileSize>100MB</maxFileSize>
-        </rollingPolicy>
-        <encoder>
-            <pattern>%msg%n</pattern>
-            <charset>UTF-8</charset>
-        </encoder>
-    </appender>
-
-    <appender name="serverproxy-access-log" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${logOutputPath}/serverproxy_access.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/serverproxy_access.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
-            <maxFileSize>100MB</maxFileSize>
-        </rollingPolicy>
-        <encoder>
-            <pattern>%msg%n</pattern>
-            <charset>UTF-8</charset>
-        </encoder>
-    </appender>
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %level [xroad-proxy] [%thread] %logger{36} - %msg%n%rEx{3}</pattern>
         </encoder>
     </appender>
 
-    <logger name="ee.ria.xroad.proxy.clientproxy.RequestLog" level="INFO" additivity="false">
-        <appender-ref ref="clientproxy-access-log"/>
-    </logger>
-
-    <logger name="ee.ria.xroad.proxy.serverproxy.RequestLog" level="INFO" additivity="false">
-        <appender-ref ref="serverproxy-access-log"/>
-    </logger>
-
-    <logger name="ee.ria.xroad" level="INFO"/>
+    <logger name="ee.ria.xroad" level="INFO" />
     <logger name="akka" level="WARN" />
 
     <root level="INFO">

--- a/sidecar/files/signer-console-logback.xml
+++ b/sidecar/files/signer-console-logback.xml
@@ -32,15 +32,13 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d %level [xroad-signer-console] [%thread] %logger{36} - %msg%n%rEx{3}</pattern>
         </encoder>
     </appender>
 
     <logger name="ee.ria.xroad" level="INFO" />
 
     <root level="INFO">
-        <appender-ref ref="FILE" />
-        <appender-ref ref="SYSLOG" />
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/sidecar/files/signer-console-logback.xml
+++ b/sidecar/files/signer-console-logback.xml
@@ -1,34 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration>
-    <contextName>X-Road Signer Console</contextName>
-
-    <property name="logOutputPath" value="/var/log/xroad" />
-
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${logOutputPath}/signer-console.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/signer-console.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
-            <maxFileSize>100MB</maxFileSize>
-        </rollingPolicy>
-        <encoder>
-            <pattern>%d %-5level [%thread] %logger{36} - %msg%n</pattern>
-            <charset>UTF-8</charset>
-        </encoder>
-    </appender>
-
-    <appender name="SYSLOG" class="ch.qos.logback.classic.net.SyslogAppender">
-        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
-                <marker>AUDIT</marker>
-            </evaluator>
-            <onMismatch>DENY</onMismatch>
-            <onMatch>NEUTRAL</onMatch>
-        </filter>
-        <syslogHost>localhost</syslogHost>
-        <port>514</port>
-        <facility>LOCAL0</facility>
-        <suffixPattern>%-5level [%contextName] %d{yyyy-MM-dd HH:mm:ssZ} - %msg</suffixPattern>
-    </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -42,7 +13,4 @@
         <appender-ref ref="STDOUT" />
     </root>
 
-    <root level="ERROR">
-        <appender-ref ref="STDOUT" />
-    </root>
 </configuration>

--- a/sidecar/files/signer-console-logback.xml
+++ b/sidecar/files/signer-console-logback.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <contextName>X-Road Signer Console</contextName>
+
+    <property name="logOutputPath" value="/var/log/xroad" />
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${logOutputPath}/signer-console.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/signer-console.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d %-5level [%thread] %logger{36} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <appender name="SYSLOG" class="ch.qos.logback.classic.net.SyslogAppender">
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+                <marker>AUDIT</marker>
+            </evaluator>
+            <onMismatch>DENY</onMismatch>
+            <onMatch>NEUTRAL</onMatch>
+        </filter>
+        <syslogHost>localhost</syslogHost>
+        <port>514</port>
+        <facility>LOCAL0</facility>
+        <suffixPattern>%-5level [%contextName] %d{yyyy-MM-dd HH:mm:ssZ} - %msg</suffixPattern>
+    </appender>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="ee.ria.xroad" level="INFO" />
+
+    <root level="INFO">
+        <appender-ref ref="FILE" />
+        <appender-ref ref="SYSLOG" />
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/sidecar/files/signer-logback.xml
+++ b/sidecar/files/signer-logback.xml
@@ -1,34 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration scan="true" scanPeriod="60 seconds">
 
-    <property name="logOutputPath" value="/var/log/xroad" />
-
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${logOutputPath}/signer.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${logOutputPath}/signer.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
-            <maxFileSize>100MB</maxFileSize>
-        </rollingPolicy>
-        <encoder>
-            <pattern>%d %-5level [%thread] %logger{36} - %msg%n</pattern>
-            <charset>UTF-8</charset>
-        </encoder>
-    </appender>
-
-    <appender name="SYSLOG" class="ch.qos.logback.classic.net.SyslogAppender">
-        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
-                <marker>AUDIT</marker>
-            </evaluator>
-            <onMismatch>DENY</onMismatch>
-            <onMatch>NEUTRAL</onMatch>
-        </filter>
-        <syslogHost>localhost</syslogHost>
-        <port>514</port>
-        <facility>LOCAL0</facility>
-        <suffixPattern>%-5level [%logger{36}] %d{yyyy-MM-dd HH:mm:ssZ} - %msg</suffixPattern>
-    </appender>
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %level [xroad-signer] [%thread] %logger{36} - %msg%n%rEx{3}</pattern>
@@ -45,7 +17,4 @@
         <appender-ref ref="STDOUT" />
     </root>
 
-    <root level="ERROR">
-        <appender-ref ref="STDOUT" />
-    </root>
 </configuration>

--- a/sidecar/files/signer-logback.xml
+++ b/sidecar/files/signer-logback.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration scan="true" scanPeriod="60 seconds">
+
+    <property name="logOutputPath" value="/var/log/xroad" />
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${logOutputPath}/signer.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logOutputPath}/signer.%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d %-5level [%thread] %logger{36} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <appender name="SYSLOG" class="ch.qos.logback.classic.net.SyslogAppender">
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+                <marker>AUDIT</marker>
+            </evaluator>
+            <onMismatch>DENY</onMismatch>
+            <onMatch>NEUTRAL</onMatch>
+        </filter>
+        <syslogHost>localhost</syslogHost>
+        <port>514</port>
+        <facility>LOCAL0</facility>
+        <suffixPattern>%-5level [%logger{36}] %d{yyyy-MM-dd HH:mm:ssZ} - %msg</suffixPattern>
+    </appender>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="ee.ria.xroad" level="INFO" />
+    <logger name="akka" level="WARN" />
+
+    <!--TokenManager is very verbose /-->
+    <logger name="ee.ria.xroad.signer.tokenmanager.TokenManager" level="OFF" />
+
+    <root level="INFO">
+        <appender-ref ref="FILE" />
+        <appender-ref ref="SYSLOG" />
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/sidecar/files/signer-logback.xml
+++ b/sidecar/files/signer-logback.xml
@@ -31,7 +31,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d %level [xroad-signer] [%thread] %logger{36} - %msg%n%rEx{3}</pattern>
         </encoder>
     </appender>
 
@@ -42,8 +42,6 @@
     <logger name="ee.ria.xroad.signer.tokenmanager.TokenManager" level="OFF" />
 
     <root level="INFO">
-        <appender-ref ref="FILE" />
-        <appender-ref ref="SYSLOG" />
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/sidecar/files/ss-xroad.conf
+++ b/sidecar/files/ss-xroad.conf
@@ -5,35 +5,49 @@ stopsignal=INT
 stopwaitsecs=30
 autorestart=unexpected
 priority=100
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:nginx]
 command=/usr/sbin/nginx -g "daemon off;"
 autorestart=unexpected
 priority=100
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:xroad-jetty]
 command=/usr/share/xroad/bin/xroad-jetty9
 user=xroad
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:xroad-signer]
 command=/usr/share/xroad/bin/xroad-signer
 user=xroad
 autorestart=true
 priority=200
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:xroad-confclient]
 command=/usr/share/xroad/bin/xroad-confclient
 user=xroad
 autorestart=true
 priority=100
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:xroad-proxy]
 command=/usr/bin/setpriv --reuid=xroad --regid=xroad --init-groups --inh-caps=-all,+NET_BIND_SERVICE --ambient-caps=-all,+NET_BIND_SERVICE /usr/share/xroad/bin/xroad-proxy
 autorestart=true
 stopwaitsecs=30
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:xroad-autologin]
 command=/usr/share/xroad/autologin/xroad-autologin-retry.sh
 user=xroad
 autorestart=false
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0


### PR DESCRIPTION
- Added logback configuration files for the sidecar modules to redirect logs to standard output.
- Modified supervisor daemon configuration to redirect child processes output to its own standard output, and thus to docker logs output.