### PR TITLE
XRDDEV-1816 add xroad-addon-messagelog service and fix some issues

### DIFF
--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-slim
 RUN mv /usr/share/xroad/jlib/addon/proxy/messagelog.conf.disabled /usr/share/xroad/jlib/addon/proxy/messagelog.conf  \

--- a/sidecar/docker-build.sh
+++ b/sidecar/docker-build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >&/dev/null && pwd)"
-version="${1:-6.26.0}"
+version="${1:-beta-7.0.0}"
 tag="${2:-xroad-security-server-sidecar}"
 build() {
   echo "BUILDING $tag:$version$2 using ${1#$dir/}"

--- a/sidecar/ee/Dockerfile
+++ b/sidecar/ee/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION
 ARG VERSION

--- a/sidecar/ee/Dockerfile
+++ b/sidecar/ee/Dockerfile
@@ -7,4 +7,4 @@ ADD https://raw.githubusercontent.com/nordic-institute/X-Road/$VERSION/src/packa
 
 RUN chown xroad:xroad /etc/xroad/conf.d/override-securityserver-ee.ini \
 && chmod 660 /etc/xroad/conf.d/override-securityserver-ee.ini \
-&& cp -p /etc/xroad/conf.d/override-securityserver-ee.ini /root/etc/xroad/conf.d/
+&& cp -p /etc/xroad/conf.d/override-securityserver-ee.ini /usr/share/xroad/config/etc/xroad/conf.d/

--- a/sidecar/fi/Dockerfile
+++ b/sidecar/fi/Dockerfile
@@ -7,4 +7,4 @@ ADD https://raw.githubusercontent.com/nordic-institute/X-Road/$VERSION/src/packa
 
 RUN chown xroad:xroad /etc/xroad/conf.d/override-securityserver-fi.ini \
 && chmod 660 /etc/xroad/conf.d/override-securityserver-fi.ini \
-&& cp -p /etc/xroad/conf.d/override-securityserver-fi.ini /root/etc/xroad/conf.d/
+&& cp -p /etc/xroad/conf.d/override-securityserver-fi.ini /usr/share/xroad/config/etc/xroad/conf.d/

--- a/sidecar/fi/Dockerfile
+++ b/sidecar/fi/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION
 ARG VERSION

--- a/sidecar/files/_entrypoint_common.sh
+++ b/sidecar/files/_entrypoint_common.sh
@@ -77,6 +77,7 @@ if [ "$INSTALLED_VERSION" == "$PACKAGED_VERSION" ]; then
     # copy if not exists
     cp -a -n "$PACKAGED_CONFIG"/backup/local.ini /etc/xroad/conf.d/
     cp -a -n "$PACKAGED_CONFIG"/backup/devices.ini /etc/xroad/
+    cp -a -n "$PACKAGED_CONFIG"/backup/local.properties /etc/xroad/services/
     # packages need to be reconfigured (runs possible db and config migrations)
     RECONFIG_REQUIRED=true
   fi

--- a/sidecar/files/primary-ss-xroad.conf
+++ b/sidecar/files/primary-ss-xroad.conf
@@ -68,3 +68,9 @@ autorestart=false
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
+[program:xroad-addon-messagelog]
+command=/usr/share/xroad/bin/xroad-messagelog-archiver
+user=xroad
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0

--- a/sidecar/files/secondary-ss-xroad.conf
+++ b/sidecar/files/secondary-ss-xroad.conf
@@ -59,3 +59,10 @@ autostart=true
 autorestart=false
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
+
+[program:xroad-addon-messagelog]
+command=/usr/share/xroad/bin/xroad-messagelog-archiver
+user=xroad
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0

--- a/sidecar/files/ss-xroad.conf
+++ b/sidecar/files/ss-xroad.conf
@@ -64,3 +64,10 @@ autorestart=true
 priority=100
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
+
+[program:xroad-addon-messagelog]
+command=/usr/share/xroad/bin/xroad-messagelog-archiver
+user=xroad
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0

--- a/sidecar/fo/Dockerfile
+++ b/sidecar/fo/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION
 ARG VERSION

--- a/sidecar/fo/Dockerfile
+++ b/sidecar/fo/Dockerfile
@@ -7,4 +7,4 @@ ADD https://raw.githubusercontent.com/nordic-institute/X-Road/$VERSION/src/packa
 
 RUN chown xroad:xroad /etc/xroad/conf.d/override-securityserver-fo.ini \
 && chmod 660 /etc/xroad/conf.d/override-securityserver-fo.ini \
-&& cp -p /etc/xroad/conf.d/override-securityserver-fo.ini /root/etc/xroad/conf.d/
+&& cp -p /etc/xroad/conf.d/override-securityserver-fo.ini /usr/share/xroad/config/etc/xroad/conf.d/

--- a/sidecar/is/Dockerfile
+++ b/sidecar/is/Dockerfile
@@ -7,4 +7,4 @@ ADD https://raw.githubusercontent.com/nordic-institute/X-Road/$VERSION/src/packa
 
 RUN chown xroad:xroad /etc/xroad/conf.d/override-securityserver-is.ini \
 && chmod 660 /etc/xroad/conf.d/override-securityserver-is.ini \
-&& cp -p /etc/xroad/conf.d/override-securityserver-is.ini /root/etc/xroad/conf.d/
+&& cp -p /etc/xroad/conf.d/override-securityserver-is.ini /usr/share/xroad/config/etc/xroad/conf.d/

--- a/sidecar/is/Dockerfile
+++ b/sidecar/is/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION
 ARG VERSION

--- a/sidecar/kubernetesBalancer/ee/primary/Dockerfile
+++ b/sidecar/kubernetesBalancer/ee/primary/Dockerfile
@@ -9,9 +9,9 @@ RUN adduser --system --shell /bin/bash --ingroup xroad xroad-slave \
 && chown xroad-slave /home/xroad-slave/.ssh \
 && crudini --set /etc/xroad/conf.d/node.ini node type 'master' \
 && chown xroad:xroad /etc/xroad/conf.d/node.ini \
-&& cp -a /etc/xroad/conf.d/node.ini /root/etc/xroad/conf.d/ \
+&& cp -a /etc/xroad/conf.d/node.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
 && crudini --set /etc/xroad/conf.d/override-docker.ini proxy server-support-clients-pooled-connections 'false' \
-&& cp -a /etc/xroad/conf.d/override-docker.ini /root/etc/xroad/conf.d/ \
+&& cp -a /etc/xroad/conf.d/override-docker.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
 && echo "StrictModes no" >>/etc/ssh/sshd_config
 
 COPY files/balancer-primary-entrypoint.sh /root/entrypoint.sh

--- a/sidecar/kubernetesBalancer/ee/primary/Dockerfile
+++ b/sidecar/kubernetesBalancer/ee/primary/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-ee
 RUN apt-get -qq update \

--- a/sidecar/kubernetesBalancer/ee/secondary/Dockerfile
+++ b/sidecar/kubernetesBalancer/ee/secondary/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -qq update \
 RUN crudini --set /etc/xroad/conf.d/node.ini node type 'slave' \
   && crudini --set /etc/xroad/conf.d/node.ini message-log archive-interval '0 * * ? * * 2099' \
   && chown xroad:xroad /etc/xroad/conf.d/node.ini \
-  && cp -a /etc/xroad/conf.d/node.ini /root/etc/xroad/conf.d/ \
+  && cp -a /etc/xroad/conf.d/node.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
   && rm -f /etc/cron.d/xroad-* /etc/cron.d/sysstat \
   && mkdir -m 0700 -p /home/xroad/.ssh \
   && chown xroad:xroad /home/xroad/.ssh

--- a/sidecar/kubernetesBalancer/ee/secondary/Dockerfile
+++ b/sidecar/kubernetesBalancer/ee/secondary/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-ee
 RUN apt-get -qq update \

--- a/sidecar/kubernetesBalancer/fi/primary/Dockerfile
+++ b/sidecar/kubernetesBalancer/fi/primary/Dockerfile
@@ -9,9 +9,9 @@ RUN adduser --system --shell /bin/bash --ingroup xroad xroad-slave \
 && chown xroad-slave /home/xroad-slave/.ssh \
 && crudini --set /etc/xroad/conf.d/node.ini node type 'master' \
 && chown xroad:xroad /etc/xroad/conf.d/node.ini \
-&& cp -a /etc/xroad/conf.d/node.ini /root/etc/xroad/conf.d/ \
+&& cp -a /etc/xroad/conf.d/node.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
 && crudini --set /etc/xroad/conf.d/override-docker.ini proxy server-support-clients-pooled-connections 'false' \
-&& cp -a /etc/xroad/conf.d/override-docker.ini /root/etc/xroad/conf.d/ \
+&& cp -a /etc/xroad/conf.d/override-docker.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
 && echo "StrictModes no" >>/etc/ssh/sshd_config
 
 COPY files/balancer-primary-entrypoint.sh /root/entrypoint.sh

--- a/sidecar/kubernetesBalancer/fi/primary/Dockerfile
+++ b/sidecar/kubernetesBalancer/fi/primary/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-fi
 RUN apt-get -qq update \

--- a/sidecar/kubernetesBalancer/fi/secondary/Dockerfile
+++ b/sidecar/kubernetesBalancer/fi/secondary/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -qq update \
 RUN crudini --set /etc/xroad/conf.d/node.ini node type 'slave' \
   && crudini --set /etc/xroad/conf.d/node.ini message-log archive-interval '0 * * ? * * 2099' \
   && chown xroad:xroad /etc/xroad/conf.d/node.ini \
-  && cp -a /etc/xroad/conf.d/node.ini /root/etc/xroad/conf.d/ \
+  && cp -a /etc/xroad/conf.d/node.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
   && rm -f /etc/cron.d/xroad-* /etc/cron.d/sysstat \
   && mkdir -m 0700 -p /home/xroad/.ssh \
   && chown xroad:xroad /home/xroad/.ssh

--- a/sidecar/kubernetesBalancer/fi/secondary/Dockerfile
+++ b/sidecar/kubernetesBalancer/fi/secondary/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-fi
 RUN apt-get -qq update \

--- a/sidecar/kubernetesBalancer/is/primary/Dockerfile
+++ b/sidecar/kubernetesBalancer/is/primary/Dockerfile
@@ -9,9 +9,9 @@ RUN adduser --system --shell /bin/bash --ingroup xroad xroad-slave \
 && chown xroad-slave /home/xroad-slave/.ssh \
 && crudini --set /etc/xroad/conf.d/node.ini node type 'master' \
 && chown xroad:xroad /etc/xroad/conf.d/node.ini \
-&& cp -a /etc/xroad/conf.d/node.ini /root/etc/xroad/conf.d/ \
+&& cp -a /etc/xroad/conf.d/node.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
 && crudini --set /etc/xroad/conf.d/override-docker.ini proxy server-support-clients-pooled-connections 'false' \
-&& cp -a /etc/xroad/conf.d/override-docker.ini /root/etc/xroad/conf.d/ \
+&& cp -a /etc/xroad/conf.d/override-docker.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
 && echo "StrictModes no" >>/etc/ssh/sshd_config
 
 COPY files/balancer-primary-entrypoint.sh /root/entrypoint.sh

--- a/sidecar/kubernetesBalancer/is/primary/Dockerfile
+++ b/sidecar/kubernetesBalancer/is/primary/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-is
 RUN apt-get -qq update \

--- a/sidecar/kubernetesBalancer/is/secondary/Dockerfile
+++ b/sidecar/kubernetesBalancer/is/secondary/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -qq update \
 RUN crudini --set /etc/xroad/conf.d/node.ini node type 'slave' \
   && crudini --set /etc/xroad/conf.d/node.ini message-log archive-interval '0 * * ? * * 2099' \
   && chown xroad:xroad /etc/xroad/conf.d/node.ini \
-  && cp -a /etc/xroad/conf.d/node.ini /root/etc/xroad/conf.d/ \
+  && cp -a /etc/xroad/conf.d/node.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
   && rm -f /etc/cron.d/xroad-* /etc/cron.d/sysstat \
   && mkdir -m 0700 -p /home/xroad/.ssh \
   && chown xroad:xroad /home/xroad/.ssh

--- a/sidecar/kubernetesBalancer/is/secondary/Dockerfile
+++ b/sidecar/kubernetesBalancer/is/secondary/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-is
 RUN apt-get -qq update \

--- a/sidecar/kubernetesBalancer/primary/Dockerfile
+++ b/sidecar/kubernetesBalancer/primary/Dockerfile
@@ -9,9 +9,9 @@ RUN adduser --system --shell /bin/bash --ingroup xroad xroad-slave \
 && chown xroad-slave /home/xroad-slave/.ssh \
 && crudini --set /etc/xroad/conf.d/node.ini node type 'master' \
 && chown xroad:xroad /etc/xroad/conf.d/node.ini \
-&& cp -a /etc/xroad/conf.d/node.ini /root/etc/xroad/conf.d/ \
+&& cp -a /etc/xroad/conf.d/node.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
 && crudini --set /etc/xroad/conf.d/override-docker.ini proxy server-support-clients-pooled-connections 'false' \
-&& cp -a /etc/xroad/conf.d/override-docker.ini /root/etc/xroad/conf.d/ \
+&& cp -a /etc/xroad/conf.d/override-docker.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
 && echo "StrictModes no" >>/etc/ssh/sshd_config
 
 COPY files/balancer-primary-entrypoint.sh /root/entrypoint.sh

--- a/sidecar/kubernetesBalancer/primary/Dockerfile
+++ b/sidecar/kubernetesBalancer/primary/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION
 RUN apt-get -qq update \

--- a/sidecar/kubernetesBalancer/secondary/Dockerfile
+++ b/sidecar/kubernetesBalancer/secondary/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -qq update \
 RUN crudini --set /etc/xroad/conf.d/node.ini node type 'slave' \
   && crudini --set /etc/xroad/conf.d/node.ini message-log archive-interval '0 * * ? * * 2099' \
   && chown xroad:xroad /etc/xroad/conf.d/node.ini \
-  && cp -a /etc/xroad/conf.d/node.ini /root/etc/xroad/conf.d/ \
+  && cp -a /etc/xroad/conf.d/node.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
   && rm -f /etc/cron.d/xroad-* /etc/cron.d/sysstat \
   && mkdir -m 0700 -p /home/xroad/.ssh \
   && chown xroad:xroad /home/xroad/.ssh

--- a/sidecar/kubernetesBalancer/secondary/Dockerfile
+++ b/sidecar/kubernetesBalancer/secondary/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION
 RUN apt-get -qq update \

--- a/sidecar/kubernetesBalancer/slim/fi/primary/Dockerfile
+++ b/sidecar/kubernetesBalancer/slim/fi/primary/Dockerfile
@@ -9,9 +9,9 @@ RUN adduser --system --shell /bin/bash --ingroup xroad xroad-slave \
 && chown xroad-slave /home/xroad-slave/.ssh \
 && crudini --set /etc/xroad/conf.d/node.ini node type 'master' \
 && chown xroad:xroad /etc/xroad/conf.d/node.ini \
-&& cp -a /etc/xroad/conf.d/node.ini /root/etc/xroad/conf.d/ \
+&& cp -a /etc/xroad/conf.d/node.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
 && crudini --set /etc/xroad/conf.d/override-docker.ini proxy server-support-clients-pooled-connections 'false' \
-&& cp -a /etc/xroad/conf.d/override-docker.ini /root/etc/xroad/conf.d/ \
+&& cp -a /etc/xroad/conf.d/override-docker.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
 && echo "StrictModes no" >>/etc/ssh/sshd_config
 
 COPY files/balancer-primary-entrypoint.sh /root/entrypoint.sh

--- a/sidecar/kubernetesBalancer/slim/fi/primary/Dockerfile
+++ b/sidecar/kubernetesBalancer/slim/fi/primary/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-slim-fi
 RUN apt-get -qq update \

--- a/sidecar/kubernetesBalancer/slim/fi/secondary/Dockerfile
+++ b/sidecar/kubernetesBalancer/slim/fi/secondary/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -qq update \
 RUN crudini --set /etc/xroad/conf.d/node.ini node type 'slave' \
   && crudini --set /etc/xroad/conf.d/node.ini message-log archive-interval '0 * * ? * * 2099' \
   && chown xroad:xroad /etc/xroad/conf.d/node.ini \
-  && cp -a /etc/xroad/conf.d/node.ini /root/etc/xroad/conf.d/ \
+  && cp -a /etc/xroad/conf.d/node.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
   && rm -f /etc/cron.d/xroad-* /etc/cron.d/sysstat \
   && mkdir -m 0700 -p /home/xroad/.ssh \
   && chown xroad:xroad /home/xroad/.ssh

--- a/sidecar/kubernetesBalancer/slim/fi/secondary/Dockerfile
+++ b/sidecar/kubernetesBalancer/slim/fi/secondary/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-slim-fi
 RUN apt-get -qq update \

--- a/sidecar/kubernetesBalancer/slim/is/primary/Dockerfile
+++ b/sidecar/kubernetesBalancer/slim/is/primary/Dockerfile
@@ -9,9 +9,9 @@ RUN adduser --system --shell /bin/bash --ingroup xroad xroad-slave \
 && chown xroad-slave /home/xroad-slave/.ssh \
 && crudini --set /etc/xroad/conf.d/node.ini node type 'master' \
 && chown xroad:xroad /etc/xroad/conf.d/node.ini \
-&& cp -a /etc/xroad/conf.d/node.ini /root/etc/xroad/conf.d/ \
+&& cp -a /etc/xroad/conf.d/node.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
 && crudini --set /etc/xroad/conf.d/override-docker.ini proxy server-support-clients-pooled-connections 'false' \
-&& cp -a /etc/xroad/conf.d/override-docker.ini /root/etc/xroad/conf.d/ \
+&& cp -a /etc/xroad/conf.d/override-docker.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
 && echo "StrictModes no" >>/etc/ssh/sshd_config
 
 COPY files/balancer-primary-entrypoint.sh /root/entrypoint.sh

--- a/sidecar/kubernetesBalancer/slim/is/primary/Dockerfile
+++ b/sidecar/kubernetesBalancer/slim/is/primary/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-slim-is
 RUN apt-get -qq update \

--- a/sidecar/kubernetesBalancer/slim/is/secondary/Dockerfile
+++ b/sidecar/kubernetesBalancer/slim/is/secondary/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -qq update \
 RUN crudini --set /etc/xroad/conf.d/node.ini node type 'slave' \
   && crudini --set /etc/xroad/conf.d/node.ini message-log archive-interval '0 * * ? * * 2099' \
   && chown xroad:xroad /etc/xroad/conf.d/node.ini \
-  && cp -a /etc/xroad/conf.d/node.ini /root/etc/xroad/conf.d/ \
+  && cp -a /etc/xroad/conf.d/node.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
   && rm -f /etc/cron.d/xroad-* /etc/cron.d/sysstat \
   && mkdir -m 0700 -p /home/xroad/.ssh \
   && chown xroad:xroad /home/xroad/.ssh

--- a/sidecar/kubernetesBalancer/slim/is/secondary/Dockerfile
+++ b/sidecar/kubernetesBalancer/slim/is/secondary/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-slim-is
 RUN apt-get -qq update \

--- a/sidecar/kubernetesBalancer/slim/primary/Dockerfile
+++ b/sidecar/kubernetesBalancer/slim/primary/Dockerfile
@@ -9,9 +9,9 @@ RUN adduser --system --shell /bin/bash --ingroup xroad xroad-slave \
 && chown xroad-slave /home/xroad-slave/.ssh \
 && crudini --set /etc/xroad/conf.d/node.ini node type 'master' \
 && chown xroad:xroad /etc/xroad/conf.d/node.ini \
-&& cp -a /etc/xroad/conf.d/node.ini /root/etc/xroad/conf.d/ \
+&& cp -a /etc/xroad/conf.d/node.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
 && crudini --set /etc/xroad/conf.d/override-docker.ini proxy server-support-clients-pooled-connections 'false' \
-&& cp -a /etc/xroad/conf.d/override-docker.ini /root/etc/xroad/conf.d/ \
+&& cp -a /etc/xroad/conf.d/override-docker.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
 && echo "StrictModes no" >>/etc/ssh/sshd_config
 
 COPY files/balancer-primary-entrypoint.sh /root/entrypoint.sh

--- a/sidecar/kubernetesBalancer/slim/primary/Dockerfile
+++ b/sidecar/kubernetesBalancer/slim/primary/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-slim
 RUN apt-get -qq update \

--- a/sidecar/kubernetesBalancer/slim/secondary/Dockerfile
+++ b/sidecar/kubernetesBalancer/slim/secondary/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -qq update \
 RUN crudini --set /etc/xroad/conf.d/node.ini node type 'slave' \
   && crudini --set /etc/xroad/conf.d/node.ini message-log archive-interval '0 * * ? * * 2099' \
   && chown xroad:xroad /etc/xroad/conf.d/node.ini \
-  && cp -a /etc/xroad/conf.d/node.ini /root/etc/xroad/conf.d/ \
+  && cp -a /etc/xroad/conf.d/node.ini /usr/share/xroad/config/etc/xroad/conf.d/ \
   && rm -f /etc/cron.d/xroad-* /etc/cron.d/sysstat \
   && mkdir -m 0700 -p /home/xroad/.ssh \
   && chown xroad:xroad /home/xroad/.ssh

--- a/sidecar/kubernetesBalancer/slim/secondary/Dockerfile
+++ b/sidecar/kubernetesBalancer/slim/secondary/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-slim
 RUN apt-get -qq update \

--- a/sidecar/slim/Dockerfile
+++ b/sidecar/slim/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:focal
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq update \
@@ -20,8 +20,10 @@ RUN apt-get -qq update \
   && apt-get -qq install postgresql postgresql-contrib \
   && apt-get -qq clean
 
-ARG DIST=focal-$VERSION
-ARG REPO=https://artifactory.niis.org/xroad-release-deb
+#ARG DIST=focal-$VERSION
+# use snapshot repo temporarily for beta 7.0 packages until 7.0 is released
+ARG DIST=focal-snapshot
+ARG REPO=https://artifactory.niis.org/xroad-snapshot-deb
 ARG REPO_KEY=https://artifactory.niis.org/api/gpg/key/public
 ARG COMPONENT=main
 ARG CERTS_PATH=/etc/xroad/ssl
@@ -71,11 +73,12 @@ RUN rm -f /etc/xroad/db.properties \
 # for initializing an empty config volume
   && mkdir -p /usr/share/xroad/config/etc/xroad /usr/share/xroad/config/backup \
   && cp -a /etc/xroad /usr/share/xroad/config/etc/ \
-  && rm -rf /usr/share/xroad/config/etc/xroad/signer/softtoken
+  && rm -rf /usr/share/xroad/config/etc/xroad/signer/softtoken \
 # move files that should not be overwritten during migration to another folder
 # (these are needed when initializing an empty config volume)
   && mv /usr/share/xroad/config/etc/xroad/conf.d/local.ini \
     /usr/share/xroad/config/etc/xroad/devices.ini \
+    /usr/share/xroad/config/etc/xroad/services/local.properties \
     /usr/share/xroad/config/backup/ \
 ##
   && dpkg-query --showformat='${Version}' --show xroad-proxy >/usr/share/xroad/config/VERSION \

--- a/sidecar/slim/fi/Dockerfile
+++ b/sidecar/slim/fi/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-slim
 ARG VERSION
@@ -6,4 +6,4 @@ ARG VERSION
 ADD --chown=xroad:xroad https://raw.githubusercontent.com/nordic-institute/X-Road/$VERSION/src/packages/src/xroad/default-configuration/override-securityserver-fi.ini /etc/xroad/conf.d/override-securityserver-fi.ini
 
 RUN chmod 660 /etc/xroad/conf.d/override-securityserver-fi.ini \
-  && cp -a /etc/xroad/conf.d/override-securityserver-fi.ini /root/etc/xroad/conf.d/
+  && cp -a /etc/xroad/conf.d/override-securityserver-fi.ini /usr/share/xroad/config/etc/xroad/conf.d/

--- a/sidecar/slim/fo/Dockerfile
+++ b/sidecar/slim/fo/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-slim
 ARG VERSION

--- a/sidecar/slim/fo/Dockerfile
+++ b/sidecar/slim/fo/Dockerfile
@@ -6,4 +6,4 @@ ARG VERSION
 ADD --chown=xroad:xroad https://raw.githubusercontent.com/nordic-institute/X-Road/$VERSION/src/packages/src/xroad/default-configuration/override-securityserver-fo.ini /etc/xroad/conf.d/override-securityserver-fo.ini
 
 RUN chmod 660 /etc/xroad/conf.d/override-securityserver-fo.ini \
-  && cp -a /etc/xroad/conf.d/override-securityserver-fo.ini /root/etc/xroad/conf.d/
+  && cp -a /etc/xroad/conf.d/override-securityserver-fo.ini /usr/share/xroad/config/etc/xroad/conf.d/

--- a/sidecar/slim/is/Dockerfile
+++ b/sidecar/slim/is/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.26.0
+ARG VERSION=beta-7.0.0
 ARG TAG=niis/xroad-security-server-sidecar
 FROM $TAG:$VERSION-slim
 ARG VERSION

--- a/sidecar/slim/is/Dockerfile
+++ b/sidecar/slim/is/Dockerfile
@@ -6,4 +6,4 @@ ARG VERSION
 ADD --chown=xroad:xroad https://raw.githubusercontent.com/nordic-institute/X-Road/$VERSION/src/packages/src/xroad/default-configuration/override-securityserver-is.ini /etc/xroad/conf.d/override-securityserver-is.ini
 
 RUN chmod 660 /etc/xroad/conf.d/override-securityserver-is.ini \
-  && cp -a /etc/xroad/conf.d/override-securityserver-is.ini /root/etc/xroad/conf.d/
+  && cp -a /etc/xroad/conf.d/override-securityserver-is.ini /usr/share/xroad/config/etc/xroad/conf.d/


### PR DESCRIPTION
https://jira.niis.org/browse/XRDDEV-1816

- add xroad-addon-messagelog service to non-slim container types
- use x-road version beta-7.0.0 packages from artifactory snapshot repository
- bump version number to beta-7.0.0
- fix broken slim/Dockerfile (missing backslash)
- fix multiple broken Dockerfiles (used old /root/etc/xroad path instead of current /usr/share/xroad/config/etc/xroad)
- add local.properties as a configuration file which must not be overwritten (new for 7.0)
- not a full sidecar 7.0.0 release, at least documentation updates and some kubernetes related updates and testing TBD