### PR TITLE
fix: typo errors on kubernetes manifests

### DIFF
--- a/doc/kubernetes_security_server_sidecar_user_guide.md
+++ b/doc/kubernetes_security_server_sidecar_user_guide.md
@@ -376,20 +376,20 @@ See [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-co
 The X-Road proxy consumer interface can be used for checking that the server is alive. Since the startup can take some time, it is recommended to also use a startup probe.
 
 ```yaml
-  startupProbe
-    httpget:
+  startupProbe:
+    httpGet:
       path: /
       port: 8080
     periodSeconds: 10
     failureThreshold: 60
 
   livenessProbe:
-    httpget:
+    httpGet:
       path: /
       port: 8080
-    periodseconds: 10
-    successthreshold: 1
-    failurethreshold: 5
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 5
 ```
 
 ##### Readiness probe
@@ -473,19 +473,19 @@ spec:
       value: "<xroad db password>"
     - name: XROAD_DATABASE_NAME
       value: "<database name>"
-  startupProbe
-    httpget:
+  startupProbe:
+    httpGet:
       path: /
       port: 8080
     periodSeconds: 10
     failureThreshold: 60
   livenessProbe:
-    httpget:
+    httpGet:
       path: /
       port: 8080
-    periodseconds: 10
-    successthreshold: 1
-    failurethreshold: 5
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 5
     ports:
     - containerPort: 4000
     - containerPort: 5588


### PR DESCRIPTION
Some Kubernetes manifests has some typo errors that should be nice to fix in the [kubernetes_security_server_sidecar_user_guide.md](doc/kubernetes_security_server_sidecar_user_guide.md) documentation file:

- Missing colons.
- Bad use of lowercamel case in [Container Probes](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) definitions.
